### PR TITLE
Don't suppress fields for custom collection model

### DIFF
--- a/upload/views_post.py
+++ b/upload/views_post.py
@@ -14,7 +14,7 @@ Col = get_collection_model()
 class ColForm(ModelForm):
     class Meta:
         model = Col
-        fields = []
+        exclude = ['user']
 
 
 class FilesEditView(DetailView):


### PR DESCRIPTION
When settings.UPLOAD_COLLECTION_MODEL is set, the upload form should ask the user to fill in other fields on the custom collection model. Instead of excluding all of the fields, just exclude the user field.